### PR TITLE
Rebrand twitter and github for DSCUnilag

### DIFF
--- a/learn.html
+++ b/learn.html
@@ -159,7 +159,7 @@
                     <a href="mailto:team@dsc.scuniversityname.org">team@dscuniversityname.org</a>
                     <ul class="social-list__inline mt-10">
                         <li>
-                            <a href="https://twitter.com/DSCUniversityName">
+                            <a href="https://twitter.com/DSCUnilag">
                                 <i class="fab fa-twitter"></i>
                             </a>
                         </li>

--- a/learn.html
+++ b/learn.html
@@ -164,7 +164,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://github.com/DSCUniversityName">
+                            <a href="https://github.com/DSC-Unilag">
                                 <i class="fab fa-github"></i>
                             </a>
                         </li>
@@ -205,7 +205,7 @@
                             <ul>
                                 <li class="list-unstyled">
                                 <li>
-                                    <a href="https://github.com/DSCUniversityName" target="_blank" rel="noopener noreferrer">Partner</a>
+                                    <a href="https://github.com/DSC-Unilag" target="_blank" rel="noopener noreferrer">Partner</a>
                                 </li>
                                 <li>
                                     <a href="https://github.com/DSCLEADSAfrica" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/projects.html
+++ b/projects.html
@@ -243,7 +243,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://github.com/DSCUniversityName">
+                            <a href="https://github.com/DSC-Unilag">
                                 <i class="fab fa-github"></i>
                             </a>
                         </li>
@@ -284,7 +284,7 @@
                             <ul>
                                 <li class="list-unstyled">
                                 <li>
-                                    <a href="https://github.com/DSCUniversityName" target="_blank" rel="noopener noreferrer">Partner</a>
+                                    <a href="https://github.com/DSC-Unilag" target="_blank" rel="noopener noreferrer">Partner</a>
                                 </li>
                                 <li>
                                     <a href="https://github.com/DSCLEADSAfrica" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/projects.html
+++ b/projects.html
@@ -238,7 +238,7 @@
                     <a href="mailto:team@dsc.scuniversityname.org">team@dscuniversityname.org</a>
                     <ul class="social-list__inline mt-10">
                         <li>
-                            <a href="https://twitter.com/DSCUniversityName">
+                            <a href="https://twitter.com/DSCUnilag">
                                 <i class="fab fa-twitter"></i>
                             </a>
                         </li>


### PR DESCRIPTION
Replace default Github and Twitter links with that of DSCUnilag
